### PR TITLE
Add post

### DIFF
--- a/app/.env.example
+++ b/app/.env.example
@@ -3,6 +3,7 @@ APP_NAME=Badapple2-API
 APP_PORT=8000
 APP_URL=localhost:${APP_PORT}
 FLASK_ENV="development"
+MAX_CONTENT_LENGTH=1048576 # 1MB - limits size of POST requests
 
 # specs for badapple_classic
 DB_HOST="localhost"

--- a/app/api_spec.yml
+++ b/app/api_spec.yml
@@ -149,7 +149,7 @@ components:
       required: false
       minimum: 1
       maximum: 10
-      default: 10
+      default: 5
       description: Ignore compounds with more than the specified number of ring systems (must be between 1 and 10).
     SMILESList:
       name: SMILES

--- a/app/config.py
+++ b/app/config.py
@@ -8,6 +8,7 @@ APP_NAME = environ.get("APP_NAME")
 APP_PORT = environ.get("APP_PORT")
 APP_URL = environ.get("APP_URL") or "localhost"
 URL_PREFIX = environ.get("URL_PREFIX") or ""
+MAX_CONTENT_LENGTH = int(environ.get("MAX_CONTENT_LENGTH"))
 
 # Database
 databases = [

--- a/app/config.py
+++ b/app/config.py
@@ -49,6 +49,9 @@ DEFAULT_DB = environ.get("DB2_NAME")
 MAX_RING_LOWER_BOUND = 1
 MAX_RING_UPPER_BOUND = 10
 
+# limits on length of input lists (e.g., SMILES)
+MAX_LIST_LENGTH = 1000
+
 # Only include this page description if in prod
 PROD_ONLY_ADDL_DESCRIPTION = """
 \n\n

--- a/app/config.py
+++ b/app/config.py
@@ -40,6 +40,8 @@ for db in databases:
     DB_NAME2PORT[db["name"]] = db["port"]
     ALLOWED_DB_NAMES.append(db["name"])
 
+DEFAULT_DB = environ.get("DB2_NAME")
+
 
 # API limits
 # limits on max rings

--- a/app/config.py
+++ b/app/config.py
@@ -48,6 +48,7 @@ DEFAULT_DB = environ.get("DB2_NAME")
 # these should match api_spec.yml
 MAX_RING_LOWER_BOUND = 1
 MAX_RING_UPPER_BOUND = 10
+MAX_RING_DEFAULT = 5
 
 # limits on length of input lists (e.g., SMILES)
 MAX_LIST_LENGTH = 1000

--- a/app/tests/README.md
+++ b/app/tests/README.md
@@ -11,13 +11,8 @@ This directory contains tests written with `pytest` to check the validity of the
    cp .env.example .env.test
    ```
 
-3. Setup and activate the project's virtual environment. For example, with conda use:
-   ```
-   conda create -n badapple2-api python=3.12 && conda activate badapple2-api
-   ```
-4. Install pip-tools: `pip install pip-tools`
-5. Sync the environment: `pip-sync`
-6. Run the tests:
+3. Setup and activate the project's virtual environment by following the instructions [here](../../docs/README.md#python-environment-setup)
+4. Run the tests:
 
    ```
    python -m pytest

--- a/app/tests/unit/test_request_processing.py
+++ b/app/tests/unit/test_request_processing.py
@@ -10,16 +10,39 @@ from flask import request
 from utils.request_processing import (
     get_database,
     int_check,
+    param_given,
     process_integer_list_input,
     process_list_input,
 )
 from werkzeug.exceptions import BadRequest
 
 
-# --------- int_check -------------
+class TestParamGiven:
+    def test_param_present(self, flask_app):
+        with flask_app.test_request_context("/?n=100"):
+            assert param_given(request, "n")
+
+    def test_param_not_present(self, flask_app):
+        with flask_app.test_request_context("/"):
+            assert param_given(request, "n") == False
+
+    def test_param_present_post(self, flask_app):
+        with flask_app.test_request_context("/", method="POST", json={"n": 100}):
+            assert param_given(request, "n")
+
+    def test_param_not_present_post(self, flask_app):
+        with flask_app.test_request_context("/", method="POST", json={}):
+            assert param_given(request, "n") == False
+
+
 class TestIntCheck:
     def test_valid_int(self, flask_app):
         with flask_app.test_request_context("/?n=5"):
+            result = int_check(request, "n", lower_limit=1, upper_limit=10)
+            assert result == 5
+
+    def test_valid_int_post(self, flask_app):
+        with flask_app.test_request_context("/", method="POST", json={"n": 5}):
             result = int_check(request, "n", lower_limit=1, upper_limit=10)
             assert result == 5
 
@@ -28,8 +51,19 @@ class TestIntCheck:
             result = int_check(request, "n", default_val=7)
             assert result == 7
 
+    def test_missing_value_uses_default_post(self, flask_app):
+        with flask_app.test_request_context("/", method="POST", json={}):
+            result = int_check(request, "n", default_val=7)
+            assert result == 7
+
     def test_below_lower_limit(self, flask_app):
         with flask_app.test_request_context("/?n=0"):
+            with pytest.raises(BadRequest) as exc:
+                int_check(request, "n", lower_limit=1)
+            assert "must be greater" in str(exc.value)
+
+    def test_below_lower_limit_post(self, flask_app):
+        with flask_app.test_request_context("/", method="POST", json={"n": 0}):
             with pytest.raises(BadRequest) as exc:
                 int_check(request, "n", lower_limit=1)
             assert "must be greater" in str(exc.value)
@@ -40,8 +74,20 @@ class TestIntCheck:
                 int_check(request, "n", upper_limit=50)
             assert "must be less" in str(exc.value)
 
+    def test_above_upper_limit_post(self, flask_app):
+        with flask_app.test_request_context("/", method="POST", json={"n": 100}):
+            with pytest.raises(BadRequest) as exc:
+                int_check(request, "n", upper_limit=50)
+            assert "must be less" in str(exc.value)
+
     def test_invalid_type(self, flask_app):
         with flask_app.test_request_context("/?n=foo"):
+            with pytest.raises(BadRequest) as exc:
+                int_check(request, "n")
+            assert "Expected int" in str(exc.value)
+
+    def test_invalid_type_post(self, flask_app):
+        with flask_app.test_request_context("/", method="POST", json={"n": "foo"}):
             with pytest.raises(BadRequest) as exc:
                 int_check(request, "n")
             assert "Expected int" in str(exc.value)
@@ -51,8 +97,12 @@ class TestIntCheck:
             result = int_check(request, "n", lower_limit=-10, upper_limit=10)
             assert result == 0
 
+    def test_zero_post(self, flask_app):
+        with flask_app.test_request_context("/", method="POST", json={"n": 0}):
+            result = int_check(request, "n", lower_limit=-10, upper_limit=10)
+            assert result == 0
 
-# ---------- get_database ----------
+
 # NOTE: assuming here that .env.test includes "badapple_classic" and "badapple2"
 
 
@@ -62,8 +112,20 @@ class TestGetDatabase:
             result = get_database(request)
             assert result == "badapple_classic"
 
+    def test_get_database_valid_post(self, flask_app):
+        with flask_app.test_request_context(
+            "/", method="POST", json={"database": "badapple_classic"}
+        ):
+            result = get_database(request)
+            assert result == "badapple_classic"
+
     def test_get_database_default(self, flask_app):
         with flask_app.test_request_context("/"):
+            result = get_database(request, default_val="badapple2")
+            assert result == "badapple2"
+
+    def test_get_database_default_post(self, flask_app):
+        with flask_app.test_request_context("/", method="POST", json={}):
             result = get_database(request, default_val="badapple2")
             assert result == "badapple2"
 
@@ -73,16 +135,36 @@ class TestGetDatabase:
                 get_database(request)
             assert "Invalid database" in str(exc.value)
 
+    def test_get_database_invalid_post(self, flask_app):
+        with flask_app.test_request_context(
+            "/", method="POST", json={"database": "not_a_real_db"}
+        ):
+            with pytest.raises(BadRequest) as exc:
+                get_database(request)
+            assert "Invalid database" in str(exc.value)
 
-# ---------- process_list_input ----------
+
 class TestProcessListInput:
     def test_process_list_input_valid(self, flask_app):
         with flask_app.test_request_context("/?ids=1,2,3"):
             result = process_list_input(request, "ids", limit=5)
             assert result == ["1", "2", "3"]
 
+    def test_process_list_input_valid_post(self, flask_app):
+        with flask_app.test_request_context(
+            "/", method="POST", json={"ids": ["1", "2", "3"]}
+        ):
+            result = process_list_input(request, "ids", limit=5)
+            assert result == ["1", "2", "3"]
+
     def test_process_list_input_missing(self, flask_app):
         with flask_app.test_request_context("/"):
+            with pytest.raises(BadRequest) as exc:
+                process_list_input(request, "ids", limit=5)
+            assert "No ids provided" in str(exc.value)
+
+    def test_process_list_input_missing_post(self, flask_app):
+        with flask_app.test_request_context("/", method="POST", json={}):
             with pytest.raises(BadRequest) as exc:
                 process_list_input(request, "ids", limit=5)
             assert "No ids provided" in str(exc.value)
@@ -93,11 +175,33 @@ class TestProcessListInput:
                 process_list_input(request, "ids", limit=5)
             assert "exceeded limit" in str(exc.value)
 
+    def test_process_list_input_exceeds_limit_post(self, flask_app):
+        with flask_app.test_request_context(
+            "/", method="POST", json={"ids": ["1", "2", "3", "4", "5", "6"]}
+        ):
+            with pytest.raises(BadRequest) as exc:
+                process_list_input(request, "ids", limit=5)
+            assert "exceeded limit" in str(exc.value)
 
-# ---------- process_integer_list_input ----------
+
 class TestProcessIntegerListInput:
     def test_process_integer_list_input_valid(self, flask_app):
         with flask_app.test_request_context("/?ids=1,2,3"):
+            result = process_integer_list_input(request, "ids", limit=5)
+            assert result == [1, 2, 3]
+
+    def test_process_integer_list_input_valid_post(self, flask_app):
+        with flask_app.test_request_context(
+            "/", method="POST", json={"ids": ["1", "2", "3"]}
+        ):
+            result = process_integer_list_input(request, "ids", limit=5)
+            assert result == [1, 2, 3]
+
+    def test_process_integer_list_input_valid_post_integers(self, flask_app):
+        """Test with actual integers in JSON (not strings)"""
+        with flask_app.test_request_context(
+            "/", method="POST", json={"ids": [1, 2, 3]}
+        ):
             result = process_integer_list_input(request, "ids", limit=5)
             assert result == [1, 2, 3]
 
@@ -106,3 +210,19 @@ class TestProcessIntegerListInput:
             with pytest.raises(BadRequest) as exc:
                 process_integer_list_input(request, "ids", limit=5)
             assert "contains non-integer elements" in str(exc.value)
+
+    def test_process_integer_list_input_non_integer_post(self, flask_app):
+        with flask_app.test_request_context(
+            "/", method="POST", json={"ids": ["1", "two", "3"]}
+        ):
+            with pytest.raises(BadRequest) as exc:
+                process_integer_list_input(request, "ids", limit=5)
+            assert "contains non-integer elements" in str(exc.value)
+
+    def test_process_integer_list_input_mixed_types_post(self, flask_app):
+        """Test with mixed integer and string types in JSON"""
+        with flask_app.test_request_context(
+            "/", method="POST", json={"ids": [1, "2", 3]}
+        ):
+            result = process_integer_list_input(request, "ids", limit=5)
+            assert result == [1, 2, 3]

--- a/app/utils/request_processing.py
+++ b/app/utils/request_processing.py
@@ -11,6 +11,7 @@ from config import (
     ALLOWED_DB_NAMES,
     DEFAULT_DB,
     MAX_LIST_LENGTH,
+    MAX_RING_DEFAULT,
     MAX_RING_LOWER_BOUND,
     MAX_RING_UPPER_BOUND,
 )
@@ -41,7 +42,7 @@ def int_check(
     return n
 
 
-def get_max_rings(request, default_val: int = 10):
+def get_max_rings(request, default_val: int = MAX_RING_DEFAULT):
     max_rings = int_check(
         request, "max_rings", MAX_RING_LOWER_BOUND, MAX_RING_UPPER_BOUND, default_val
     )

--- a/app/utils/request_processing.py
+++ b/app/utils/request_processing.py
@@ -18,6 +18,41 @@ from config import (
 from flask import abort
 
 
+def _method_not_supported(request):
+    return abort(405, f"Method {request.method} not supported")
+
+
+def param_given(request, param_name: str):
+    param_given = False
+    if request.method == "GET":
+        param_given = param_name in request.args
+    elif request.method == "POST":
+        param_given = param_name in request.json
+    else:
+        return _method_not_supported(request)
+    return param_given
+
+
+def get_param(request, param_name: str, type, default_val=None):
+    val = None
+    if request.method == "GET":
+        val = request.args.get(param_name, type=type)
+    elif request.method == "POST":
+        val = request.json.get(param_name)
+    else:
+        return _method_not_supported(request)
+    if val is None:
+        val = default_val
+    return val
+
+
+def get_required_param(request, param_name: str, type):
+    val = get_param(request, param_name, type)
+    if not val:  # None or empty
+        return abort(400, f"No {param_name} provided")
+    return val
+
+
 def int_check(
     request,
     var_name: str,
@@ -25,9 +60,7 @@ def int_check(
     upper_limit: Union[None, int] = None,
     default_val: Union[None, int] = None,
 ):
-    n = request.args.get(var_name, type=int)
-    if n is None:
-        n = default_val
+    n = get_param(request, var_name, type=int, default_val=default_val)
     try:
         n = int(n)
     except:
@@ -42,9 +75,13 @@ def int_check(
     return n
 
 
-def get_max_rings(request, default_val: int = MAX_RING_DEFAULT):
+def get_max_rings(request):
     max_rings = int_check(
-        request, "max_rings", MAX_RING_LOWER_BOUND, MAX_RING_UPPER_BOUND, default_val
+        request,
+        "max_rings",
+        MAX_RING_LOWER_BOUND,
+        MAX_RING_UPPER_BOUND,
+        MAX_RING_DEFAULT,
     )
     return max_rings
 
@@ -54,23 +91,17 @@ def get_database(
     default_val: str = DEFAULT_DB,
     allowed_db_names: list[str] = ALLOWED_DB_NAMES,
 ):
-    database = request.args.get("database", type=str) or default_val
+    database = get_param(request, "database", type=str, default_val=default_val)
     if database not in allowed_db_names:
         db_names = ",".join(allowed_db_names)
         return abort(400, f"Invalid database provided, select from: {db_names}")
     return database
 
 
-def get_required_param(request, param_name: str, type):
-    val = request.args.get(param_name, type=type)
-    if not val:  # None or empty
-        return abort(400, f"No {param_name} provided")
-    return val
-
-
 def process_list_input(request, param_name: str, limit: int = MAX_LIST_LENGTH):
     value_list = get_required_param(request, param_name, type=str)
-    value_list = value_list.split(",")
+    if request.method == "GET":
+        value_list = value_list.split(",")
     if len(value_list) > limit:
         return abort(
             400,
@@ -82,7 +113,7 @@ def process_list_input(request, param_name: str, limit: int = MAX_LIST_LENGTH):
 def process_integer_list_input(request, param_name: str, limit: int = MAX_LIST_LENGTH):
     int_list = process_list_input(request, param_name, limit)
     try:
-        int_list = [int(cid) for cid in int_list]
+        int_list = [int(x) for x in int_list]
     except ValueError:
         return abort(
             400,

--- a/app/utils/request_processing.py
+++ b/app/utils/request_processing.py
@@ -7,7 +7,12 @@ Functions related to parsing requests.
 
 from typing import Union
 
-from config import ALLOWED_DB_NAMES, MAX_RING_LOWER_BOUND, MAX_RING_UPPER_BOUND
+from config import (
+    ALLOWED_DB_NAMES,
+    DEFAULT_DB,
+    MAX_RING_LOWER_BOUND,
+    MAX_RING_UPPER_BOUND,
+)
 from flask import abort
 
 
@@ -44,10 +49,9 @@ def get_max_rings(request, default_val: int = 10):
 
 def get_database(
     request,
-    default_val: str = ALLOWED_DB_NAMES[0],
+    default_val: str = DEFAULT_DB,
     allowed_db_names: list[str] = ALLOWED_DB_NAMES,
 ):
-    # ALLOWED_DB_NAMES[0] == "badapple_classic"
     database = request.args.get("database", type=str) or default_val
     if database not in allowed_db_names:
         db_names = ",".join(allowed_db_names)

--- a/app/utils/request_processing.py
+++ b/app/utils/request_processing.py
@@ -10,6 +10,7 @@ from typing import Union
 from config import (
     ALLOWED_DB_NAMES,
     DEFAULT_DB,
+    MAX_LIST_LENGTH,
     MAX_RING_LOWER_BOUND,
     MAX_RING_UPPER_BOUND,
 )
@@ -66,7 +67,7 @@ def get_required_param(request, param_name: str, type):
     return val
 
 
-def process_list_input(request, param_name: str, limit: int):
+def process_list_input(request, param_name: str, limit: int = MAX_LIST_LENGTH):
     value_list = get_required_param(request, param_name, type=str)
     value_list = value_list.split(",")
     if len(value_list) > limit:
@@ -77,7 +78,7 @@ def process_list_input(request, param_name: str, limit: int):
     return value_list
 
 
-def process_integer_list_input(request, param_name: str, limit):
+def process_integer_list_input(request, param_name: str, limit: int = MAX_LIST_LENGTH):
     int_list = process_list_input(request, param_name, limit)
     try:
         int_list = [int(cid) for cid in int_list]

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,9 +4,10 @@ This folder contains reference materials.
 
 ## Python Environment Setup
 
-1. Setup and activate the project's virtual environment. For example, with conda use:
+1. Make sure you are in the `/app` folder: `cd app/`
+2. Setup and activate the project's virtual environment. For example, with conda use:
    ```
    conda create -n badapple2-api python=3.12 && conda activate badapple2-api
    ```
-2. Install pip-tools: `pip install pip-tools`
-3. Sync the environment: `pip-sync`
+3. Install pip-tools: `pip install pip-tools`
+4. Sync the environment: `pip-sync`

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,12 @@
+# Docs
+
+This folder contains reference materials.
+
+## Python Environment Setup
+
+1. Setup and activate the project's virtual environment. For example, with conda use:
+   ```
+   conda create -n badapple2-api python=3.12 && conda activate badapple2-api
+   ```
+2. Install pip-tools: `pip install pip-tools`
+3. Sync the environment: `pip-sync`

--- a/example_scripts/README.md
+++ b/example_scripts/README.md
@@ -4,6 +4,8 @@ This directory contains example scripts which make use of the Badapple2 API.
 
 ## Script Usage
 
+**Prior to running scripts make sure you are in the badapple2-api environment, see [here](../docs/README.md#python-environment-setup)**
+
 ### `get_compound_scores.py`
 
 This script processes an input CSV/TSV file containing compound structures and outputs information on all of the scaffolds linked to these compounds in the Badapple database.

--- a/local.env
+++ b/local.env
@@ -20,6 +20,7 @@ APP_NAME=Badapple2-API
 UI_PORT=8080 # for website/UI
 APP_PORT=8000
 APP_URL=localhost:${APP_PORT}
+MAX_CONTENT_LENGTH=1048576 # 1MB - limits size of POST requests
 VITE_API_FETCH_SCAFFOLDS_URL=http://${APP_URL}/api/v1/compound_search/get_associated_scaffolds_ordered
 VITE_API_FETCH_DRUGS_URL=http://${APP_URL}/api/v1/scaffold_search/get_associated_drugs
 VITE_API_FETCH_TARGETS_URL=http://${APP_URL}/api/v1/scaffold_search/get_active_targets

--- a/production_env.example
+++ b/production_env.example
@@ -27,6 +27,7 @@ APP_NAME=Badapple2-API
 APP_PORT=8001
 URL_PREFIX=badapple2
 APP_URL=chiltepin.health.unm.edu/${URL_PREFIX}
+MAX_CONTENT_LENGTH=1048576 # 1MB - limits size of POST requests
 VITE_API_FETCH_SCAFFOLDS_URL=https://${APP_URL}/api/v1/compound_search/get_associated_scaffolds_ordered
 VITE_API_FETCH_DRUGS_URL=https://${APP_URL}/api/v1/scaffold_search/get_associated_drugs
 VITE_API_FETCH_TARGETS_URL=https://${APP_URL}/api/v1/scaffold_search/get_active_targets


### PR DESCRIPTION
These  changes add support for POST requests to the `compound_search/get_associated_scaffolds` and `compound_search/get_associated_scaffolds_ordered` endpoints. Although neither of these endpoints are destructive (i.e., modify data), using POST allows for us to process more than a small handful of compounds at a time. See:
https://medium.com/swlh/why-would-you-use-post-instead-of-get-for-a-read-operation-381e4bdf3b9a