### PR TITLE
use more than 1 worker with gunicorn, set max_requests

### DIFF
--- a/app/.env.example
+++ b/app/.env.example
@@ -5,6 +5,10 @@ APP_URL=localhost:${APP_PORT}
 FLASK_ENV="development"
 MAX_CONTENT_LENGTH=1048576 # 1MB - limits size of POST requests
 
+# gunicorn - unlikely that you'd need to change these vals
+N_WORKERS=3
+MAX_REQUESTS=1000
+
 # specs for badapple_classic
 DB_HOST="localhost"
 DB_NAME="badapple_classic"

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -12,6 +12,8 @@ COPY . .
 RUN mkdir -p flasgger_static && \
     cp -r /usr/local/lib/python3.12/site-packages/flasgger/ui3/static/* flasgger_static
 
-# can be overridden by docker compose
+# ENV vars can be overridden by docker compose / .env file
 ENV APP_PORT=8000
-CMD echo "RUNTIME: APP_PORT is set to ${APP_PORT}" && gunicorn --bind "0.0.0.0:${APP_PORT}" --reload app:app
+ENV N_WORKERS=3
+ENV MAX_REQUESTS=1000
+CMD echo "RUNTIME: APP_PORT=${APP_PORT}, N_WORKERS=${N_WORKERS}, MAX_REQUESTS=${MAX_REQUESTS}" && gunicorn --bind "0.0.0.0:${APP_PORT}" --workers ${N_WORKERS} --max-requests ${MAX_REQUESTS} --reload app:app

--- a/local.env
+++ b/local.env
@@ -26,3 +26,7 @@ VITE_API_FETCH_DRUGS_URL=http://${APP_URL}/api/v1/scaffold_search/get_associated
 VITE_API_FETCH_ACTIVE_ASSAYS_URL=http://localhost:${APP_PORT}/api/v1/scaffold_search/get_active_assay_details
 VITE_DB_NAME=${DB_NAME}
 VITE_DB2_NAME=${DB2_NAME}
+
+# for gunicorn
+N_WORKERS=3
+MAX_REQUESTS=1000 # unlikely that you'd need to change this

--- a/production_env.example
+++ b/production_env.example
@@ -33,3 +33,7 @@ VITE_API_FETCH_DRUGS_URL=https://${APP_URL}/api/v1/scaffold_search/get_associate
 VITE_API_FETCH_ACTIVE_ASSAYS_URL=https://${APP_URL}/api/v1/scaffold_search/get_active_assay_details
 VITE_DB_NAME=${DB_NAME}
 VITE_DB2_NAME=${DB2_NAME}
+
+# for gunicorn
+N_WORKERS=3
+MAX_REQUESTS=1000 # unlikely that you'd need to change this


### PR DESCRIPTION
Allow config to use multiple workers instead of 1, will help with multiple client requests made simultaneously (e.g., multiple users on the website at the same time).

Default value of 3 is based on `2 x $(NUM_CORES) + 1`, where `$(NUM_CORES) = 1`. See https://docs.gunicorn.org/en/stable/settings.html 